### PR TITLE
Clear the validation status before validate it again.

### DIFF
--- a/modules/ui/form.js
+++ b/modules/ui/form.js
@@ -67,6 +67,10 @@ M.FormView = M.View.extend(
         for(var name in ids) {
             var view = M.ViewManager.getViewById(ids[name]);
             if(view && view.validators) {
+                if(view.cssClassOnError) {
+                    view.removeCssClass(view.cssClassOnError);
+                }
+
                 _.each(view.validators, function(validator) {
                     if(!validator.validate(view, name)) {
                         isValid = NO;


### PR DESCRIPTION
Current behavior is that if the view is in error state, even
the user input is valid, the UI will still show it as invalid.
