### PR TITLE
Supports putting an asterisk to the right of the label for a textfield

### DIFF
--- a/modules/ui/text_field.js
+++ b/modules/ui/text_field.js
@@ -208,6 +208,20 @@ M.TextFieldView = M.View.extend(
     recommendedEvents: ['focus', 'blur', 'enter', 'keyup', 'tap'],
 
     /**
+     * Define whether putting an asterisk to the right of the label for this textfield.
+     *
+     * @type Boolean
+     */
+    hasAsteriskOnLabel: NO,
+
+    /**
+     * This property can be used to assign a css class to the asterisk on the right of the label.
+     *
+     * @type String
+     */
+    cssClassForAsterisk: null,
+
+    /**
      * Renders a TextFieldView
      * 
      * @private
@@ -228,7 +242,15 @@ M.TextFieldView = M.View.extend(
         this.html += '>';
 
         if(this.label) {
-            this.html += '<label for="' + (this.name ? this.name : this.id) + '">' + this.label + '</label>';
+            if(this.hasAsteriskOnLabel) {
+                if(this.cssClassForAsterisk) {
+                    this.html += '<label for="' + (this.name ? this.name : this.id) + '">' + this.label + '<span class="' + this.cssClassForAsterisk + '">*</span></label>';
+                } else {
+                    this.html += '<label for="' + (this.name ? this.name : this.id) + '">' + this.label + '<span>*</span></label>';
+                }
+            } else {
+                this.html += '<label for="' + (this.name ? this.name : this.id) + '">' + this.label + '</label>';
+            }
         }
 
         if(this.hasMultipleLines) {


### PR DESCRIPTION
Add two new properties for TextFieldView:
1. hasAsteriskOnLabel
    Type: Boolean
    Default Value: NO
    Description: Define whether putting an asterisk to the right of the
label for this textfield.
1. cssClassForAsterisk
   Type: String
   Default Value: N/A
   Description: This property can be used to assign a css class to the
   asterisk on the right of the label.

I think it is a pretty useful feature for creating a form, if no one objects, I would like to add this small enhancement to all similar views that have a label.
