### PR TITLE
TabBarItemView fix

### DIFF
--- a/modules/ui/tab_bar_item.js
+++ b/modules/ui/tab_bar_item.js
@@ -85,6 +85,7 @@ M.TabBarItemView = M.View.extend(
      */
     switchPage: function() {
         if(this.page) {
+        	M.ViewManager.setCurrentPage(M.ViewManager.getPage(this.page));
             M.Controller.switchToTab(this);
         } else {
             this.parentView.setActiveTab(this);


### PR DESCRIPTION
I found that when a user navigates to another page by clicking a TabBarItem, the currentPage property in M.ViewManager is not set accordingly. This small patch fixes this issue.
