### PR TITLE
Unecessary check in list.js

### DIFF
--- a/modules/ui/list.js
+++ b/modules/ui/list.js
@@ -294,7 +294,7 @@ M.ListView = M.View.extend(
         var that = this;
 
         /* Get the list view's content as an object from the assigned content binding */
-        if(this.contentBinding && typeof(this.contentBinding.target) === 'object' && typeof(this.contentBinding.property) === 'string' && this.value && this.value.length > 0) {
+        if(this.contentBinding && typeof(this.contentBinding.target) === 'object' && typeof(this.contentBinding.property) === 'string' && this.value) {
             var content = this.value;
         } else {
             M.Logger.log('The specified content binding for the list view (' + this.id + ') is invalid!', M.WARN);


### PR DESCRIPTION
When I started using the detox branch for development, I noticed that my ListView (isDividedList = YES) did not function anymore. Upon investigating, i found that the contentBinding was not being accepted anymore and no binding occurred. 

This was due to the final check in the if-test in list.js:300 that asserts that "this.value.length" should be larger than 0. 

In a simple ListView, the property containing the contentBinding is a regular list -> .length property available. In case of a dividedListView, the property is an object in the form:

```
{
    "dividerName": {
        0: ...,
        1: ...,
        ...
    }
}
```

the which does not have a .length property and does cancels the binding and triggers the warning:

```
The specified content binding for the list view (m_140) is invalid!
```

By simply removing the additional if-check i was able to fix this issue.
