### PR TITLE
Added support for multiple pattern notations in a single valuePattern

### DIFF
--- a/modules/ui/list.js
+++ b/modules/ui/list.js
@@ -439,7 +439,8 @@ M.ListView = M.View.extend(
             obj[childViewsArray[i]] = this.cloneObject(obj[childViewsArray[i]], item);
 
             /* This regex looks for a variable inside the template view (<%= ... %>) ... */
-            var regexResult = /^<%=\s+([.|_|-|$|§|@|a-zA-Z0-9]+)\s*%>$/.exec(obj[childViewsArray[i]].computedValue ? obj[childViewsArray[i]].computedValue.valuePattern : obj[childViewsArray[i]].valuePattern);
+            var pattern = obj[childViewsArray[i]].computedValue ? obj[childViewsArray[i]].computedValue.valuePattern : obj[childViewsArray[i]].valuePattern;
+            var regexResult = /<%=\s+([.|_|-|$|§|@|a-zA-Z0-9]+)\s*%>/.exec(pattern);
 
             /* ... if a match was found, the variable is replaced by the corresponding value inside the record */
             if(regexResult) {
@@ -448,7 +449,11 @@ M.ListView = M.View.extend(
                     case 'M.ButtonView':
                     case 'M.ImageView':
                     case 'M.TextFieldView':
-                        obj[childViewsArray[i]].value = record[regexResult[1]];
+                        while(regexResult !== null) {
+                            pattern = pattern.replace(regexResult[0], record[regexResult[1]]);
+                            regexResult = /<%=\s+([.|_|-|$|§|@|a-zA-Z0-9]+)\s*%>/.exec(pattern);
+                        }
+                        obj[childViewsArray[i]].value = pattern;
                         break;
                 }
             }


### PR DESCRIPTION
valuePattern now supports notations such as

```
"<%= prop1 %> &ndash; <%= prop2 %>"
```

and will replace both template holders with the appropriate properties on the bound object.
