### PR TITLE
Added a preRender hooks to ListItemView and ContainerView

### DIFF
--- a/modules/ui/container.js
+++ b/modules/ui/container.js
@@ -28,6 +28,11 @@ M.ContainerView = M.View.extend(
     type: 'M.ContainerView',
 
     /**
+     * Function to be executed before rendering of the View starts.
+     */
+    beforeRender: null,
+
+    /**
      * Renders a simple div container and applies css classes if specified.
      *
      * @private
@@ -51,6 +56,11 @@ M.ContainerView = M.View.extend(
      */
     style: function() {
         var html = '';
+
+        if (this.beforeRender) {
+            this.beforeRender();
+        }
+
         if(this.cssClass) {
             html += ' class="' + this.cssClass + '"';
         }

--- a/modules/ui/list_item.js
+++ b/modules/ui/list_item.js
@@ -65,6 +65,11 @@ M.ListItemView = M.View.extend(
     isDivider: NO,
 
     /**
+     * Function to be executed before rendering of the View starts.
+     */
+    beforeRender: null,
+
+    /**
      * This property specifies the recommended events for this type of view.
      *
      * @type Array
@@ -125,6 +130,10 @@ M.ListItemView = M.View.extend(
      * @returns {String} The list item view's html representation.
      */
     render: function() {
+        if (this.beforeRender) {
+            this.beforeRender();
+        }
+
         this.html = '<li id="' + this.id + '"' + this.style();
 
         if(this.isDivider) {
@@ -198,6 +207,10 @@ M.ListItemView = M.View.extend(
         var html = '';
         if(this.cssClass) {
             html += ' class="' + this.cssClass + '"';
+        }
+        if(this.icon) {
+            html += ' data-icon="';
+            html += this.icon + '"';
         }
         return html;
     },


### PR DESCRIPTION
This allows the user to manipulate the ListItemView and ContainerView before being rendered. 

Example: The user wishes to change the cssClass on a ContainerView in a ListItemView.

```
listItemTemplate = M.ListItemView.design({
    childViews: "myContainer",
    contentBinding: { .. },

    myContainer: M.ContainerView.design({

        // new pre-render logic proposal
        beforeRender: function() {
            if (this.parentView.item.property == YES) {
                this.cssClass = "other-css-class";
            }
        },

        cssClass = "original-css-class"
    })

})
```

Note: please consider opening a discussion on this pull request and improve upon it if deemed incomplete.
