### PR TITLE
Fix a potential infinite loop when notifying observers

### DIFF
--- a/modules/core/foundation/observable.js
+++ b/modules/core/foundation/observable.js
@@ -75,7 +75,7 @@ M.Observable = M.Object.extend(
      */
     notifyObservers: function(key) {
         _.each(this.bindingList, function(entry){
-            if((key === entry.observable || (entry.observable.indexOf('.') > 0 && entry.observable.indexOf(key) > -1)) || (key.indexOf('.') > 0 && entry.observable.indexOf(key.substring(0, key.lastIndexOf('.'))))) {
+            if((key === entry.observable || (entry.observable.indexOf('.') > 0 && entry.observable.indexOf(key) > -1)) || (key.indexOf('.') > 0 && entry.observable.indexOf(key.substring(0, key.lastIndexOf('.'))) >-1)) {
                 if(entry.observer.valueBinding && (key === entry.observer.valueBinding.property || key === entry.observer.valueBinding.property.split('.')[0])){
                     entry.observer.valueDidChange();
                 }else{


### PR DESCRIPTION
When setting a controller property having the form 'property.childProperty'
e.g. having a dot form, the if condition will incorrectly match all the observers. If
one of the observers calculates one of the observed fields the calls set,
the notification will be triggered endlessly.
