### PR TITLE
fix toggle switch won't refresh correctly

### DIFF
--- a/modules/ui/toggleswitch.js
+++ b/modules/ui/toggleswitch.js
@@ -181,6 +181,7 @@ M.ToggleSwitchView = M.View.extend(
                 $('#' + this.id + ' option[value*=' + val + ']').attr('selected', 'selected');
             }
             //toggle the view
+            $('#' + this.id).val(val);
             $('#' + this.id).slider('refresh');
         },
 


### PR DESCRIPTION
Enviroment:
    Gecko: (firefox / firefox os simulator)

Reproduce Steps:
    1. have a default toggle switch view with boolean values
    2. set toggle to true (from js), it works
    3. set toggle to false (from js), it works
    3. set toggle to true (from js), faild, the ui remains on true(on)
