### PR TITLE
fix getLanguage in i18n.js

### DIFF
--- a/modules/core/utility/i18n.js
+++ b/modules/core/utility/i18n.js
@@ -142,7 +142,7 @@ M.I18N = M.Object.extend(
         if(language) {
             return language;
         } else if(navigator) {
-            var regexResult = /([a-zA-Z]{2,3})[\s_.-]?([a-zA-Z]{2,3})?/.exec(navigator.language);
+            var regexResult = /([a-zA-Z]{2,3})[\s_.-]?([a-zA-Z]{2,3})?/.exec(navigator.language.toLowerCase().replace('-', '_'));
             if(regexResult && this[regexResult[0]]) {
                 return regexResult[0].toLowerCase();
             } else if(regexResult && regexResult[1] && this.languageMapper[regexResult[1]]) {


### PR DESCRIPTION
we need to normalize the language string before trying to match them
with available languages:
1. in lower case
2. replace '-' by '_'

ex. zh-TW => zh_tw, zh-CN => zh_cn
