### PR TITLE
M.ListView handling objects in valuePattern.

### DIFF
--- a/modules/ui/list.js
+++ b/modules/ui/list.js
@@ -477,13 +477,8 @@ M.ListView = M.View.extend(
                     case 'M.ImageView':
                     case 'M.TextFieldView':
                         while(regexResult !== null) {
-                            if(typeof(record[regexResult[1]]) === 'object') {
-                                pattern = record[regexResult[1]];
-                                regexResult = null;
-                            } else {
-                                pattern = pattern.replace(regexResult[0], record[regexResult[1]]);
-                                regexResult = /<%=\s+([.|_|-|$|§|@|a-zA-Z0-9\s]+)\s+%>/.exec(pattern);
-                            }
+							pattern = pattern.replace(regexResult[0], record[regexResult[1]]);
+							regexResult = /<%=\s+([.|_|-|$|§|@|a-zA-Z0-9\s]+)\s+%>/.exec(pattern);
                         }
                         obj[childViewsArray[i]].value = pattern;
                         break;


### PR DESCRIPTION
Changed 'cloneObject' method in M.ListView class. With this solution you can use JavaScript object as values in valuePattern. toString method will be invoked on this object and returned value will replace <%= %> tag.

Originally when object was present in values, valuePattern was ignored.
